### PR TITLE
Issue 2980: Creating an initial list of storage trackers for STP

### DIFF
--- a/data/StorageTrackingProtection.dat
+++ b/data/StorageTrackingProtection.dat
@@ -1,0 +1,1 @@
+t.co,plus.url.google.com,bit.ly,ow.ly,away.vk.com,an.yandex.ru,buff.ly,t.umbler.com,pass.tmall.com,eepurl.com


### PR DESCRIPTION
Fix https://github.com/brave/brave-browser/issues/2980

## Description
Smart tracking protection (or STP) will help block 1p storage trackers that are used to profile users (see: https://webkit.org/blog/8311/intelligent-tracking-prevention-2-0/) . This feature is in PR for brave-core https://github.com/brave/brave-core/pull/403. StorageTrackingProtection.dat will be used by tracking_protection component to check if the redirection chain (on click the user goes through a list of intermediate domains before landing on the final domain) has any trackers. 

If the user has tracking protection enabled for a domain, STP will check if the urls in the redirect chain are storage trackers and block access to the Storage APIs (localStorage/sessionStorage/IndexedDB/WebSQL) for the storage trackers. 

Initial list is populated from the blog post: https://brave.com/redirection-based-tracking/

Going forward this list will be generated by the crawler that @snyderp worked on. 

auditors: @bsclifton, @snyderp