### PR TITLE
Update Disconnect list

### DIFF
--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -10747,6 +10747,34 @@
             "ads-twitter.com"
           ]
         }
+      },
+      {
+        "Cnet": {
+          "https://www.cnet.com/": [
+            "2mdn.net"
+          ]
+        }
+      },
+      {
+        "Alexa": {
+          "http://www.alexa.com/": [
+            "pcache.alexa.com"
+          ]
+        }
+      },
+      {
+        "Saturn": {
+          "https://www.saturn.at/": [
+            "google-analytics.com"
+          ]
+        }
+      },
+      {
+        "Mediamarkt": {
+          "https://www.mediamarkt.at/": [
+            "google-analytics.com"
+          ]
+        }
       }
     ]
   }

--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -1,5 +1,5 @@
 {
-  "license": "Copyright 2010-2018 Disconnect, Inc. / This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. / This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. / You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.",
+  "license": "Copyright 2010-2019 Disconnect, Inc. / This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version. / This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. / You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.",
   "categories": {
     "Advertising": [
       {
@@ -123,6 +123,13 @@
         }
       },
       {
+        "Adabra": {
+          "https://www.adabra.com/": [
+            "adabra.com"
+          ]
+        }
+      },
+      {
         "Adality": {
           "http://adality.de/": [
             "adality.de",
@@ -161,6 +168,13 @@
         }
       },
       {
+        "Adbot": {
+          "https://adbot.tw/": [
+            "adbot.tw"
+          ]
+        }
+      },
+      {
         "Adbrain": {
           "http://www.adbrain.com/": [
             "adbrn.com",
@@ -193,16 +207,6 @@
         "AdCirrus": {
           "http://adcirrus.com/": [
             "adcirrus.com"
-          ]
-        }
-      },
-      {
-        "Adconion": {
-          "http://www.adconion.com/": [
-            "adconion.com",
-            "amgdgt.com",
-            "euroclick.com",
-            "smartclip.com"
           ]
         }
       },
@@ -321,6 +325,13 @@
         "Adfusion": {
           "http://www.adfusion.com/": [
             "adfusion.com"
+          ]
+        }
+      },
+      {
+        "AdGainerSolutions": {
+          "http://adgainersolutions.com/adgainer/": [
+            "adgainersolutions.com"
           ]
         }
       },
@@ -493,6 +504,17 @@
         }
       },
       {
+        "AdMaven": {
+          "https://ad-maven.com/": [
+            "rensovetors.info",
+            "boudja.com",
+            "ad-maven.com",
+            "agreensdistra.info",
+            "wrethicap.info"
+          ]
+        }
+      },
+      {
         "AdMaximizer Network": {
           "http://admaximizer.com/": [
             "admaximizer.com"
@@ -567,6 +589,13 @@
         }
       },
       {
+        "Adnium": {
+          "https://adnium.com": [
+            "adnium.com"
+          ]
+        }
+      },
+      {
         "adnologies": {
           "http://www.adnologies.com/": [
             "adnologies.com",
@@ -620,14 +649,6 @@
         "AdOnion": {
           "http://www.adonion.com/": [
             "adonion.com"
-          ]
-        }
-      },
-      {
-        "AdOn Network": {
-          "http://adonnetwork.com/": [
-            "adonnetwork.com",
-            "dashboardad.net"
           ]
         }
       },
@@ -775,13 +796,6 @@
           "http://www.adside.com/": [
             "adside.com",
             "doclix.com"
-          ]
-        }
-      },
-      {
-        "AdSmart": {
-          "http://adsmart.com/": [
-            "adsmart.com"
           ]
         }
       },
@@ -934,7 +948,8 @@
         "Adverticum": {
           "http://www.adverticum.com/": [
             "adverticum.com",
-            "adverticum.net"
+            "adverticum.net",
+            "adsmart.com"
           ]
         }
       },
@@ -1009,7 +1024,8 @@
         "AdYouLike": {
           "https://www.adyoulike.com/": [
             "omnitagjs.com",
-            "adyoulike.com"
+            "adyoulike.com",
+            "pulpix.com"
           ]
         }
       },
@@ -1121,7 +1137,14 @@
         }
       },
       {
-        "AllStar Media": {
+        "Albacross": {
+          "https://albacross.com": [
+            "albacross.com"
+          ]
+        }
+      },
+      {
+        "AllStarMediaGroup": {
           "http://allstarmediagroup.com/": [
             "allstarmediagroup.com"
           ]
@@ -1160,7 +1183,12 @@
       {
         "Amobee": {
           "http://amobee.com/": [
-            "amobee.com"
+            "amobee.com",
+            "adconion.com",
+            "amgdgt.com",
+            "euroclick.com",
+            "smartclip.com",
+            "turn.com"
           ]
         }
       },
@@ -1188,6 +1216,13 @@
             "tacoda.net",
             "adtechjp.com",
             "vidible.tv"
+          ]
+        }
+      },
+      {
+        "AppCast": {
+          "https://appcast.io/": [
+            "appcast.io"
           ]
         }
       },
@@ -1331,8 +1366,7 @@
         "Augur": {
           "http://www.augur.io/": [
             "augur.io"
-          ],
-          "fingerprinting": "true"
+          ]
         }
       },
       {
@@ -1375,6 +1409,23 @@
         "AWeber": {
           "http://www.aweber.com/": [
             "aweber.com"
+          ]
+        }
+      },
+      {
+        "Awin": {
+          "http://www.awin.com/": [
+            "digitalwindow.com",
+            "perfiliate.com",
+            "dwin1.com"
+          ]
+        }
+      },
+      {
+        "Azet": {
+          "http://mediaimpact.sk/": [
+            "rsz.sk",
+            "azetklik.sk"
           ]
         }
       },
@@ -1452,6 +1503,13 @@
         }
       },
       {
+        "BidSwitch": {
+          "https://www.bidswitch.com/": [
+            "bidswitch.net"
+          ]
+        }
+      },
+      {
         "Bidtellect": {
           "https://www.bidtellect.com/": [
             "bttrack.com",
@@ -1467,7 +1525,15 @@
         }
       },
       {
-        "bigmir)net": {
+        "BigClick": {
+          "http://bigclick.me/": [
+            "bgclck.me",
+            "xcvgdf.party"
+          ]
+        }
+      },
+      {
+        "bigmirnet": {
           "http://www.bigmir.net/": [
             "bigmir.net"
           ]
@@ -1484,6 +1550,13 @@
         "Bitcoin Plus": {
           "http://www.bitcoinplus.com/": [
             "bitcoinplus.com"
+          ]
+        }
+      },
+      {
+        "BitMedia": {
+          "https://bitmedia.io/": [
+            "bitmedia.io"
           ]
         }
       },
@@ -1548,14 +1621,6 @@
         }
       },
       {
-        "BlueCava": {
-          "http://www.bluecava.com/": [
-            "bluecava.com"
-          ],
-          "fingerprinting": "true"
-        }
-      },
-      {
         "BlueKai": {
           "http://www.bluekai.com/": [
             "bkrtx.com",
@@ -1579,10 +1644,18 @@
         }
       },
       {
+        "BoostBox": {
+          "https://www.boostbox.com.br/": [
+            "boostbox.com.br"
+          ]
+        }
+      },
+      {
         "Bouncex": {
           "https://www.bouncex.com/": [
             "bouncex.com",
-            "bounceexchange.com"
+            "bounceexchange.com",
+            "bouncex.net"
           ]
         }
       },
@@ -1601,6 +1674,13 @@
         }
       },
       {
+        "Brandcrumb": {
+          "http://www.brandcrumb.com": [
+            "brandcrumb.com"
+          ]
+        }
+      },
+      {
         "Brand.net": {
           "http://www.brand.net/": [
             "brand.net"
@@ -1612,6 +1692,13 @@
           "http://www.brandscreen.com/": [
             "brandscreen.com",
             "rtbidder.net"
+          ]
+        }
+      },
+      {
+        "BreakTime": {
+          "https://www.breaktime.com.tw/": [
+            "breaktime.com.tw"
           ]
         }
       },
@@ -1636,6 +1723,13 @@
         "Brilig": {
           "http://www.brilig.com/": [
             "brilig.com"
+          ]
+        }
+      },
+      {
+        "BuckSense": {
+          "http://www.bucksense.com": [
+            "bucksense.com"
           ]
         }
       },
@@ -1682,13 +1776,6 @@
         }
       },
       {
-        "BuzzCity": {
-          "http://www.buzzcity.com/": [
-            "buzzcity.com"
-          ]
-        }
-      },
-      {
         "BuzzParadise": {
           "http://www.buzzparadise.com/": [
             "buzzparadise.com"
@@ -1697,11 +1784,19 @@
       },
       {
         "BV! MEDIA": {
-          "http://www.buzzcity.com/": [
-            "buzzcity.com",
+          "http://www.bvmedia.ca/": [
             "bvmedia.ca",
             "networldmedia.com",
             "networldmedia.net"
+          ]
+        }
+      },
+      {
+        "C3 Metrics": {
+          "http://c3metrics.com/": [
+            "attributionmodel.com",
+            "c3metrics.com",
+            "c3tag.com"
           ]
         }
       },
@@ -1739,6 +1834,13 @@
           "http://www.cart.ro/": [
             "cart.ro",
             "statistics.ro"
+          ]
+        }
+      },
+      {
+        "CartsGuru": {
+          "https://carts.guru/": [
+            "carts.guru"
           ]
         }
       },
@@ -1810,6 +1912,13 @@
         }
       },
       {
+        "ClearLink": {
+          "https://www.clearlink.com/": [
+            "clearlink.com"
+          ]
+        }
+      },
+      {
         "ClearSaleing": {
           "http://www.clearsaleing.com/": [
             "clearsaleing.com",
@@ -1843,6 +1952,13 @@
         }
       },
       {
+        "Clickayab": {
+          "http://www.clickyab.com": [
+            "clickyab.com"
+          ]
+        }
+      },
+      {
         "Clickbooth": {
           "http://www.clickbooth.com/": [
             "clickbooth.com",
@@ -1862,6 +1978,13 @@
           "http://www.clickdistrict.com/": [
             "clickdistrict.com",
             "creative-serving.com"
+          ]
+        }
+      },
+      {
+        "ClickFrog": {
+          "https://clickfrog.ru/": [
+            "clickfrog.ru"
           ]
         }
       },
@@ -1902,6 +2025,13 @@
         }
       },
       {
+        "Clixtell": {
+          "https://www.clixtell.com/": [
+            "clixtell.com"
+          ]
+        }
+      },
+      {
         "Clove Network": {
           "http://www.clovenetwork.com/": [
             "clovenetwork.com"
@@ -1917,19 +2047,6 @@
             "cmmeglobal.com",
             "cognitivematch.com"
           ]
-        }
-      },
-      {
-        "CoinHive": {
-          "https://coinhive.com": [
-            "coinhive.com",
-            "coin-hive.com",
-            "cnhv.co",
-            "authedmine.com",
-            "wsservices.org"
-          ],
-          "performance": "true",
-          "cryptominer": "true"
         }
       },
       {
@@ -1984,7 +2101,17 @@
       {
         "comScore": {
           "http://www.comscore.com/": [
-            "adxpose.com"
+            "adxpose.com",
+            "proximic.com",
+            "proxilinks.com",
+            "proximic.net"
+          ]
+        }
+      },
+      {
+        "Connexity": {
+          "http://www.connexity.com/": [
+            "pricegrabber.com"
           ]
         }
       },
@@ -1992,6 +2119,13 @@
         "Consilium Media": {
           "http://www.consiliummedia.com/": [
             "consiliummedia.com"
+          ]
+        }
+      },
+      {
+        "Consumable": {
+          "http://consumable.com/": [
+            "consumable.com"
           ]
         }
       },
@@ -2037,6 +2171,25 @@
           "http://www.convergedirect.com/": [
             "convergedirect.com",
             "convergetrack.com"
+          ]
+        }
+      },
+      {
+        "ConversantMedia": {
+          "http://conversantmedia.com": [
+            "adserver.com",
+            "dotomi.com",
+            "dtmpub.com",
+            "emjcd.com",
+            "fastclick.com",
+            "fastclick.net",
+            "greystripe.com",
+            "lduhtrp.net",
+            "mediaplex.com",
+            "valueclick.com",
+            "valueclick.net",
+            "valueclickmedia.com",
+            "conversantmedia.com"
           ]
         }
       },
@@ -2111,7 +2264,9 @@
         "Criteo": {
           "http://www.criteo.com/": [
             "criteo.com",
-            "criteo.net"
+            "criteo.net",
+            "hooklogic.com",
+            "hlserve.com"
           ]
         }
       },
@@ -2125,20 +2280,13 @@
         }
       },
       {
-        "CryptoLoot": {
-          "https://crypto-loot.com": [
-            "crypto-loot.com",
-            "cryptaloot.pro",
-            "webmine.pro"
-          ],
-          "cryptominer": "true",
-          "performance": "true"
-        }
-      },
-      {
         "cXense": {
           "http://www.cxense.com/": [
-            "cxense.com"
+            "cxense.com",
+            "emediate.com",
+            "emediate.biz",
+            "emediate.dk",
+            "emediate.eu"
           ]
         }
       },
@@ -2300,14 +2448,6 @@
         }
       },
       {
-        "Digital Window": {
-          "http://www.digitalwindow.com/": [
-            "digitalwindow.com",
-            "perfiliate.com"
-          ]
-        }
-      },
-      {
         "Digitize": {
           "http://www.digitize.ie/": [
             "digitize.ie"
@@ -2337,6 +2477,20 @@
         }
       },
       {
+        "Disqus": {
+          "http://disqus.com/": [
+            "disqusads.com"
+          ]
+        }
+      },
+      {
+        "dmpxs": {
+          "http://bob.dmpxs.com": [
+            "dmpxs.com"
+          ]
+        }
+      },
+      {
         "DoublePimp": {
           "http://doublepimp.com/": [
             "doublepimp.com"
@@ -2349,14 +2503,6 @@
             "bid-tag.com",
             "doublepositive.com"
           ]
-        }
-      },
-      {
-        "DoubleVerify": {
-          "http://www.doubleverify.com/": [
-            "doubleverify.com"
-          ],
-          "fingerprinting": "true"
         }
       },
       {
@@ -2444,16 +2590,6 @@
         "Eleavers": {
           "http://eleavers.com/": [
             "eleavers.com"
-          ]
-        }
-      },
-      {
-        "Emediate": {
-          "http://www.emediate.com/": [
-            "emediate.biz",
-            "emediate.com",
-            "emediate.dk",
-            "emediate.eu"
           ]
         }
       },
@@ -2574,18 +2710,18 @@
         }
       },
       {
-        "Everyday Health": {
-          "http://www.everydayhealth.com/": [
-            "everydayhealth.com",
-            "waterfrontmedia.com"
+        "Evergage": {
+          "http://www.evergage.com": [
+            "mybuys.com",
+            "veruta.com"
           ]
         }
       },
       {
-        "Evidon": {
-          "http://www.evidon.com/": [
-            "betrad.com",
-            "evidon.com"
+        "Everyday Health": {
+          "http://www.everydayhealth.com/": [
+            "everydayhealth.com",
+            "waterfrontmedia.com"
           ]
         }
       },
@@ -2655,8 +2791,7 @@
         "Experian": {
           "http://www.experian.com/": [
             "audienceiq.com",
-            "experian.com",
-            "pricegrabber.com"
+            "experian.com"
           ]
         }
       },
@@ -2701,12 +2836,18 @@
         }
       },
       {
+        "EyeNewton": {
+          "http://eyenewton.ru/": [
+            "eyenewton.ru"
+          ]
+        }
+      },
+      {
         "eyeReturn Marketing": {
           "http://www.eyereturnmarketing.com/": [
             "eyereturn.com",
             "eyereturnmarketing.com"
-          ],
-          "fingerprinting": "true"
+          ]
         }
       },
       {
@@ -2740,6 +2881,13 @@
         "faithadnet": {
           "http://www.faithadnet.com/": [
             "faithadnet.com"
+          ]
+        }
+      },
+      {
+        "Fanplayr": {
+          "https://fanplayr.com/": [
+            "fanplayr.com"
           ]
         }
       },
@@ -2813,13 +2961,6 @@
         }
       },
       {
-        "Flurry": {
-          "http://www.flurry.com/": [
-            "flurry.com"
-          ]
-        }
-      },
-      {
         "Flytxt": {
           "http://www.flytxt.com/": [
             "flytxt.com"
@@ -2842,8 +2983,7 @@
             "foxonestop.com",
             "mobsmith.com",
             "myads.com",
-            "othersonline.com",
-            "rubiconproject.com"
+            "othersonline.com"
           ]
         }
       },
@@ -2871,10 +3011,25 @@
         }
       },
       {
+        "Friends2Follow": {
+          "https://friends2follow.com/": [
+            "friends2follow.com"
+          ]
+        }
+      },
+      {
         "Frog Sex": {
           "http://www.frogsex.com/": [
             "double-check.com",
             "frogsex.com"
+          ]
+        }
+      },
+      {
+        "FuelX": {
+          "https://fuelx.com/": [
+            "fuelx.com",
+            "fuel451.com"
           ]
         }
       },
@@ -2993,6 +3148,13 @@
         }
       },
       {
+        "Gleam": {
+          "https://gleam.io/": [
+            "gleam.io"
+          ]
+        }
+      },
+      {
         "Globe7": {
           "http://www.globe7.com/": [
             "globe7.com"
@@ -3029,16 +3191,6 @@
         }
       },
       {
-        "Gridcash": {
-          "https://www.gridcash.net/": [
-            "adless.io",
-            "gridcash.net"
-          ],
-          "performance": "true",
-          "cryptominer": "true"
-        }
-      },
-      {
         "Grocery Shopping Network": {
           "http://www.groceryshopping.net/": [
             "groceryshopping.net"
@@ -3057,8 +3209,7 @@
           "http://www.guj.de/": [
             "guj.de",
             "ligatus.com"
-          ],
-          "fingerprinting": "true"
+          ]
         }
       },
       {
@@ -3127,18 +3278,19 @@
         }
       },
       {
-        "Hi-media": {
-          "http://www.hi-media.com/": [
-            "comclick.com",
-            "hi-media.com"
+        "HilltopAds": {
+          "https://hilltopads.com/": [
+            "hilltopads.com",
+            "hilltopads.net",
+            "shoporielder.pro"
           ]
         }
       },
       {
-        "HookLogic": {
-          "http://www.hooklogic.com/": [
-            "hlserve.com",
-            "hooklogic.com"
+        "Hi-media": {
+          "http://www.hi-media.com/": [
+            "comclick.com",
+            "hi-media.com"
           ]
         }
       },
@@ -3148,6 +3300,20 @@
             "horyzon-media.com",
             "meetic-partners.com",
             "smartadserver.com"
+          ]
+        }
+      },
+      {
+        "HotelChamp": {
+          "https://www.hotelchamp.com": [
+            "hotelchamp.com"
+          ]
+        }
+      },
+      {
+        "HotMart": {
+          "https://www.hotmart.com/en/": [
+            "hotmart.com"
           ]
         }
       },
@@ -3197,7 +3363,7 @@
         }
       },
       {
-        "I-Behavior": {
+        "iBehavior": {
           "http://www.i-behavior.com/": [
             "i-behavior.com",
             "ib-ibi.com"
@@ -3240,6 +3406,13 @@
             "ignitionone.com",
             "ignitionone.net",
             "searchignite.com"
+          ]
+        }
+      },
+      {
+        "iMedia": {
+          "http://www.imedia.cz": [
+            "imedia.cz"
           ]
         }
       },
@@ -3443,10 +3616,9 @@
         }
       },
       {
-        "isocket": {
-          "https://www.isocket.com/": [
-            "adsbyisocket.com",
-            "isocket.com"
+        "ismatlab.com": {
+          "http://ismatlab.com": [
+            "ismatlab.com"
           ]
         }
       },
@@ -3509,15 +3681,6 @@
         }
       },
       {
-        "JSE": {
-          "http://jsecoin.com": [
-            "jsecoin.com"
-          ],
-          "cryptominer": "true",
-          "performance": "true"
-        }
-      },
-      {
         "JuicyAds": {
           "http://www.juicyads.com/": [
             "juicyads.com"
@@ -3528,6 +3691,13 @@
         "Jumptap": {
           "http://www.jumptap.com/": [
             "jumptap.com"
+          ]
+        }
+      },
+      {
+        "justuno": {
+          "https://www.justuno.com/": [
+            "justuno.com"
           ]
         }
       },
@@ -3648,14 +3818,6 @@
         }
       },
       {
-        "LeadLander": {
-          "http://www.leadlander.com/": [
-            "leadlander.com",
-            "trackalyzer.com"
-          ]
-        }
-      },
-      {
         "Legolas Media": {
           "http://www.legolas-media.com/": [
             "legolas-media.com"
@@ -3747,6 +3909,13 @@
         }
       },
       {
+        "Localytics": {
+          "https://www.localytics.com/": [
+            "localytics.com"
+          ]
+        }
+      },
+      {
         "LockerDome": {
           "https://lockerdome.com/": [
             "lockerdome.com"
@@ -3776,9 +3945,23 @@
         }
       },
       {
+        "LotLinx": {
+          "https://www.lotlinx.com": [
+            "lotlinx.com"
+          ]
+        }
+      },
+      {
         "Lower My Bills": {
           "http://lowermybills.com": [
             "lowermybills.com"
+          ]
+        }
+      },
+      {
+        "lptracker": {
+          "https://lptracker.io/": [
+            "lptracker.io"
           ]
         }
       },
@@ -3915,15 +4098,10 @@
             "matomy.com",
             "matomymarket.com",
             "matomymedia.com",
-            "xtendmedia.com"
-          ]
-        }
-      },
-      {
-        "Matomy Market": {
-          "http://www.matomy.com/": [
+            "xtendmedia.com",
             "adsmarket.com",
-            "matomy.com"
+            "mediawhiz.com",
+            "adnetinteractive.com"
           ]
         }
       },
@@ -3984,10 +4162,9 @@
           "http://www.mediamath.com/": [
             "adroitinteractive.com",
             "designbloxlive.com",
-            "mathtag.com",
-            "mediamath.com"
-          ],
-          "fingerprinting": "true"
+            "mediamath.com",
+            "mathtag.com"
+          ]
         }
       },
       {
@@ -4017,14 +4194,6 @@
         "MediaTrust": {
           "http://www.mediatrust.com/": [
             "mediatrust.com"
-          ]
-        }
-      },
-      {
-        "MediaWhiz": {
-          "http://www.mediawhiz.com/": [
-            "adnetinteractive.com",
-            "mediawhiz.com"
           ]
         }
       },
@@ -4060,6 +4229,14 @@
         "Merchenta": {
           "http://www.merchenta.com/": [
             "merchenta.com"
+          ]
+        }
+      },
+      {
+        "Merkle": {
+          "https://www.merkleinc.com/": [
+            "rimmkaufman.com",
+            "rkdms.com"
           ]
         }
       },
@@ -4126,15 +4303,6 @@
         }
       },
       {
-        "Mineralt": {
-          "https://mineralt.io/": [
-            "mineralt.io"
-          ],
-          "performance": "true",
-          "cryptominer": "true"
-        }
-      },
-      {
         "Mirando": {
           "http://www.mirando.de/": [
             "mirando.de"
@@ -4160,6 +4328,13 @@
         "MobFox": {
           "http://www.mobfox.com/": [
             "mobfox.com"
+          ]
+        }
+      },
+      {
+        "Mobials": {
+          "http://mobials.com": [
+            "mobials.com"
           ]
         }
       },
@@ -4279,14 +4454,6 @@
           "http://www.mundomedia.com/": [
             "mundomedia.com",
             "silver-path.com"
-          ]
-        }
-      },
-      {
-        "MyBuys": {
-          "http://www.mybuys.com/": [
-            "mybuys.com",
-            "veruta.com"
           ]
         }
       },
@@ -4515,6 +4682,14 @@
         }
       },
       {
+        "OneAd": {
+          "https://www.onead.com.tw/": [
+            "onevision.com.tw",
+            "guoshipartners.com"
+          ]
+        }
+      },
+      {
         "One iota": {
           "http://www.itsoneiota.com/": [
             "itsoneiota.com",
@@ -4527,6 +4702,13 @@
           "http://www.oneupweb.com/": [
             "oneupweb.com",
             "sodoit.com"
+          ]
+        }
+      },
+      {
+        "OnlineMetrix": {
+          "http://h.online-metrix.net": [
+            "online-metrix.net"
           ]
         }
       },
@@ -4724,6 +4906,13 @@
         }
       },
       {
+        "PerimeterX": {
+          "https://www.perimeterx.com": [
+            "perimeterx.net"
+          ]
+        }
+      },
+      {
         "Pheedo": {
           "http://site.pheedo.com/": [
             "pheedo.com"
@@ -4739,6 +4928,13 @@
         }
       },
       {
+        "PinPoll": {
+          "https://pinpoll.com/": [
+            "pinpoll.com"
+          ]
+        }
+      },
+      {
         "Pixel.sg": {
           "http://www.pixel.sg/": [
             "pixel.sg"
@@ -4749,6 +4945,13 @@
         "Piximedia": {
           "http://www.piximedia.com/": [
             "piximedia.com"
+          ]
+        }
+      },
+      {
+        "Pixlee": {
+          "https://www.pixlee.com/": [
+            "pixlee.com"
           ]
         }
       },
@@ -4841,6 +5044,13 @@
         }
       },
       {
+        "PPCProtect": {
+          "https://ppcprotect.com": [
+            "ppcprotect.com"
+          ]
+        }
+      },
+      {
         "PrecisionClick": {
           "http://www.precisionclick.com/": [
             "precisionclick.com"
@@ -4877,7 +5087,15 @@
             "popcde.com",
             "primevisibility.com",
             "sdfje.com",
-            "urtbk.com"
+            "urtbk.com",
+            "dashboardad.net"
+          ]
+        }
+      },
+      {
+        "PrismApp": {
+          "https://www.prismapp.io/": [
+            "prismapp.io"
           ]
         }
       },
@@ -4898,6 +5116,13 @@
         }
       },
       {
+        "PrometheusIntelligenceTechnology": {
+          "https://prometheusintelligencetechnology.com/": [
+            "prometheusintelligencetechnology.com"
+          ]
+        }
+      },
+      {
         "Propeller Ads": {
           "http://propellerads.com/": [
             "propellerads.com"
@@ -4912,11 +5137,24 @@
         }
       },
       {
-        "Proximic": {
-          "http://www.proximic.com/": [
-            "proxilinks.com",
-            "proximic.com",
-            "proximic.net"
+        "Protected Media": {
+          "http://www.protected.media/": [
+            "protected.media",
+            "ad-score.com"
+          ]
+        }
+      },
+      {
+        "Provers": {
+          "http://provers.pro": [
+            "provers.pro"
+          ]
+        }
+      },
+      {
+        "Psonstrentie": {
+          "http://psonstrentie.info": [
+            "psonstrentie.info"
           ]
         }
       },
@@ -4976,8 +5214,7 @@
       },
       {
         "QUISMA": {
-          "http://www.i-behavior.com/": [
-            "i-behavior.com",
+          "https://quisma.com/": [
             "iaded.com",
             "quisma.com",
             "quismatch.com",
@@ -5093,6 +5330,13 @@
         }
       },
       {
+        "Reporo": {
+          "http://www.reporo.com/": [
+            "buzzcity.com"
+          ]
+        }
+      },
+      {
         "Resolution Media": {
           "http://resolutionmedia.com/": [
             "resolutionmedia.com"
@@ -5100,17 +5344,11 @@
         }
       },
       {
-        "Reson8": {
-          "http://reson8.com/": [
-            "reson8.com"
-          ]
-        }
-      },
-      {
         "Resonate": {
           "http://www.resonateinsights.com/": [
             "resonateinsights.com",
-            "resonatenetworks.com"
+            "resonatenetworks.com",
+            "reson8.com"
           ]
         }
       },
@@ -5195,7 +5433,9 @@
           "http://rocketfuel.com/": [
             "rfihub.com",
             "rfihub.net",
-            "rocketfuel.com"
+            "rocketfuel.com",
+            "ru4.com",
+            "xplusone.com"
           ]
         }
       },
@@ -5203,6 +5443,15 @@
         "Rovion": {
           "http://www.rovion.com/": [
             "rovion.com"
+          ]
+        }
+      },
+      {
+        "RubiconProject": {
+          "http://rubiconproject.com/": [
+            "rubiconproject.com",
+            "isocket.com",
+            "adsbyisocket.com"
           ]
         }
       },
@@ -5249,6 +5498,13 @@
           "http://www.samurai-factory.jp/": [
             "samurai-factory.jp",
             "shinobi.jp"
+          ]
+        }
+      },
+      {
+        "SAP": {
+          "https://www.sap.com": [
+            "seewhy.com"
           ]
         }
       },
@@ -5309,6 +5565,13 @@
         }
       },
       {
+        "Semantiqo": {
+          "http://semantiqo.com/": [
+            "semantiqo.com"
+          ]
+        }
+      },
+      {
         "Semasio": {
           "http://www.semasio.com/": [
             "semasio.com",
@@ -5331,6 +5594,13 @@
         }
       },
       {
+        "ShaftTraffic": {
+          "https://shafttraffic.com": [
+            "libertystmedia.com"
+          ]
+        }
+      },
+      {
         "ShareASale": {
           "http://www.shareasale.com/": [
             "shareasale.com"
@@ -5348,6 +5618,13 @@
         "Shopzilla": {
           "http://www.shopzilla.com/": [
             "shopzilla.com"
+          ]
+        }
+      },
+      {
+        "Shortest": {
+          "http://shorte.st/": [
+            "shorte.st"
           ]
         }
       },
@@ -5451,6 +5728,13 @@
         }
       },
       {
+        "Socital": {
+          "https://www.socital.com": [
+            "socital.com"
+          ]
+        }
+      },
+      {
         "Sonobi": {
           "http://sonobi.com/": [
             "sonobi.com"
@@ -5470,15 +5754,6 @@
           "http://spacechimpmedia.com/": [
             "spacechimpmedia.com"
           ]
-        }
-      },
-      {
-        "SpareChange": {
-          "http://sparechange.io": [
-            "sparechange.io"
-          ],
-          "performance": "true",
-          "cryptominer": "true"
         }
       },
       {
@@ -5801,14 +6076,6 @@
         }
       },
       {
-        "The Rimm-Kaufman Group": {
-          "http://www.rimmkaufman.com/": [
-            "rimmkaufman.com",
-            "rkdms.com"
-          ]
-        }
-      },
-      {
         "The Search Agency": {
           "http://www.thesearchagency.com/": [
             "thesearchagency.com",
@@ -6072,6 +6339,14 @@
         }
       },
       {
+        "Upland": {
+          "https://uplandsoftware.com/": [
+            "leadlander.com",
+            "trackalyzer.com"
+          ]
+        }
+      },
+      {
         "up-value": {
           "http://www.up-value.de/": [
             "up-value.de"
@@ -6094,24 +6369,6 @@
         }
       },
       {
-        "ValueClick": {
-          "http://www.valueclick.com/": [
-            "adserver.com",
-            "dotomi.com",
-            "dtmpub.com",
-            "emjcd.com",
-            "fastclick.com",
-            "fastclick.net",
-            "greystripe.com",
-            "lduhtrp.net",
-            "mediaplex.com",
-            "valueclick.com",
-            "valueclick.net",
-            "valueclickmedia.com"
-          ]
-        }
-      },
-      {
         "Various": {
           "http://www.various.com/": [
             "amigos.com",
@@ -6119,13 +6376,6 @@
             "medley.com",
             "nostringsattached.com",
             "various.com"
-          ]
-        }
-      },
-      {
-        "Vcmedia": {
-          "http://vcmedia.vn/": [
-            "vcmedia.vn"
           ]
         }
       },
@@ -6174,6 +6424,13 @@
         }
       },
       {
+        "Vendemore": {
+          "https://vendemore.com/": [
+            "vendemore.com"
+          ]
+        }
+      },
+      {
         "Vendio": {
           "http://www.vendio.com/": [
             "singlefeed.com",
@@ -6192,6 +6449,13 @@
         "Veremedia": {
           "http://www.veremedia.com/": [
             "veremedia.com"
+          ]
+        }
+      },
+      {
+        "VerticalHealth": {
+          "https://www.verticalhealth.com/": [
+            "verticalhealth.net"
           ]
         }
       },
@@ -6216,6 +6480,13 @@
         "VigLink": {
           "http://www.viglink.com/": [
             "viglink.com"
+          ]
+        }
+      },
+      {
+        "ViralLoops": {
+          "https://viral-loops.com": [
+            "viral-loops.com"
           ]
         }
       },
@@ -6297,20 +6568,18 @@
         }
       },
       {
+        "Webmecanik": {
+          "https://www.webmecanik.com/": [
+            "webmecanik.com"
+          ]
+        }
+      },
+      {
         "WebMetro": {
           "http://www.webmetro.com/": [
             "dsmmadvantage.com",
             "webmetro.com"
           ]
-        }
-      },
-      {
-        "Webmine": {
-          "https://webmine.cz/": [
-            "webmine.cz",
-            "authedwebmine.cz"
-          ],
-          "cryptominer": "true"
         }
       },
       {
@@ -6326,6 +6595,13 @@
           "http://www.webtraffic.se/": [
             "webtraffic.no",
             "webtraffic.se"
+          ]
+        }
+      },
+      {
+        "WideOrbit": {
+          "https://www.wideorbit.com/": [
+            "dep-x.com"
           ]
         }
       },
@@ -6384,14 +6660,6 @@
         }
       },
       {
-        "[x+1]": {
-          "http://www.xplusone.com/": [
-            "ru4.com",
-            "xplusone.com"
-          ]
-        }
-      },
-      {
         "xAd": {
           "http://www.xad.com/": [
             "xad.com"
@@ -6445,7 +6713,9 @@
             "thewheelof.com",
             "yieldmanager.com",
             "yieldmanager.net",
-            "yldmgrimg.net"
+            "yldmgrimg.net",
+            "flurry.com",
+            "ads.yahoo.com"
           ]
         }
       },
@@ -6575,6 +6845,15 @@
         }
       },
       {
+        "ZafulAffiliate": {
+          "https://affiliate.zaful.com/": [
+            "zaful.com",
+            "gw-ec.com",
+            "affasi.com"
+          ]
+        }
+      },
+      {
         "Zango": {
           "http://www.zango.com/": [
             "metricsdirect.com",
@@ -6604,6 +6883,13 @@
           "http://www.zedo.com/": [
             "zedo.com",
             "zincx.com"
+          ]
+        }
+      },
+      {
+        "Zefir": {
+          "https://ze-fir.com/": [
+            "ze-fir.com"
           ]
         }
       },
@@ -6671,7 +6957,9 @@
         "Adobe": {
           "http://www.adobe.com/": [
             "adobe.com",
-            "typekit.com"
+            "typekit.com",
+            "livefyre.com",
+            "fyre.co"
           ]
         }
       },
@@ -6935,7 +7223,6 @@
       {
         "Facebook": {
           "http://www.facebook.com/": [
-            "akamaihd.net",
             "instagram.com",
             "fbcdn.net",
             "messenger.com"
@@ -7270,6 +7557,13 @@
         }
       },
       {
+        "IBM": {
+          "http://www.ibm.com/": [
+            "xtify.com"
+          ]
+        }
+      },
+      {
         "iovation": {
           "http://www.iovation.com/": [
             "iesnare.com",
@@ -7301,14 +7595,6 @@
         }
       },
       {
-        "Livefyre": {
-          "http://livefyre.com/": [
-            "fyre.co",
-            "livefyre.com"
-          ]
-        }
-      },
-      {
         "LivePerson": {
           "http://www.liveperson.net/": [
             "liveperson.net"
@@ -7327,14 +7613,6 @@
           "http://www.longtailvideo.com/": [
             "longtailvideo.com",
             "ltassrv.com"
-          ]
-        }
-      },
-      {
-        "Luminate": {
-          "http://luminate.com/": [
-            "luminate.com",
-            "pixazza.com"
           ]
         }
       },
@@ -7434,6 +7712,13 @@
             "instantservice.com",
             "istrack.com",
             "oracle.com"
+          ]
+        }
+      },
+      {
+        "Outbrain": {
+          "http://www.outbrain.com/": [
+            "visualrevenue.com"
           ]
         }
       },
@@ -7603,20 +7888,6 @@
         }
       },
       {
-        "Tumblr": {
-          "http://www.tumblr.com/": [
-            "tumblr.com"
-          ]
-        }
-      },
-      {
-        "Turn": {
-          "http://www.turn.com/": [
-            "turn.com"
-          ]
-        }
-      },
-      {
         "TurnTo": {
           "http://www.turntonetworks.com/": [
             "turnto.com",
@@ -7729,13 +8000,6 @@
         }
       },
       {
-        "Visual Revenue": {
-          "http://visualrevenue.com/": [
-            "visualrevenue.com"
-          ]
-        }
-      },
-      {
         "Voice2Page": {
           "http://www.voice2page.com/": [
             "voice2page.com"
@@ -7764,13 +8028,6 @@
           "http://wingify.com/": [
             "visualwebsiteoptimizer.com",
             "wingify.com"
-          ]
-        }
-      },
-      {
-        "Xtify": {
-          "http://xtify.com/": [
-            "xtify.com"
           ]
         }
       },
@@ -7814,7 +8071,10 @@
             "yimg.com",
             "ypolicyblog.com",
             "yuilibrary.com",
-            "zenfs.com"
+            "zenfs.com",
+            "luminate.com",
+            "pixazza.com",
+            "tumblr.com"
           ]
         }
       },
@@ -7889,6 +8149,13 @@
         }
       },
       {
+        "AdScore": {
+          "http://www.adscoremarketing.com/": [
+            "adsco.re"
+          ]
+        }
+      },
+      {
         "Adventori": {
           "https://adventori.com": [
             "adventori.com"
@@ -7900,6 +8167,13 @@
           "http://www.aidata.me/": [
             "advombat.ru",
             "aidata.me"
+          ]
+        }
+      },
+      {
+        "AivaLabs": {
+          "https://aivalabs.com": [
+            "aivalabs.com"
           ]
         }
       },
@@ -7955,6 +8229,13 @@
         }
       },
       {
+        "AvantLink": {
+          "http://www.avantlink.com/": [
+            "avmws.com"
+          ]
+        }
+      },
+      {
         "Awio": {
           "http://www.awio.com/": [
             "awio.com",
@@ -7975,6 +8256,13 @@
         }
       },
       {
+        "BetssonPalantir": {
+          "https://betssonpalantir.com/": [
+            "betssonpalantir.com"
+          ]
+        }
+      },
+      {
         "BlogCounter.com": {
           "http://www.blogcounter.de/": [
             "blogcounter.de"
@@ -7989,10 +8277,24 @@
         }
       },
       {
+        "BlueCava": {
+          "http://www.bluecava.com/": [
+            "bluecava.com"
+          ]
+        }
+      },
+      {
         "Bluemetrix": {
           "http://www.bluemetrix.com/": [
             "bluemetrix.com",
             "bmmetrix.com"
+          ]
+        }
+      },
+      {
+        "Bombora": {
+          "https://bombora.com/": [
+            "ml314.com"
           ]
         }
       },
@@ -8006,7 +8308,8 @@
       {
         "BrightEdge": {
           "http://www.brightedge.com/": [
-            "brightedge.com"
+            "brightedge.com",
+            "b0e8.com"
           ]
         }
       },
@@ -8014,15 +8317,6 @@
         "Bubblestat": {
           "http://www.bubblestat.com/": [
             "bubblestat.com"
-          ]
-        }
-      },
-      {
-        "C3 Metrics": {
-          "http://c3metrics.com/": [
-            "attributionmodel.com",
-            "c3metrics.com",
-            "c3tag.com"
           ]
         }
       },
@@ -8045,6 +8339,13 @@
         "Clickdensity": {
           "http://www.clickdensity.com/": [
             "clickdensity.com"
+          ]
+        }
+      },
+      {
+        "ClickGuard": {
+          "https://www.clickguard.com/": [
+            "clickguard.com"
           ]
         }
       },
@@ -8116,14 +8417,6 @@
         }
       },
       {
-        "Conversant Media": {
-          "http://www.conversantmedia.com/": [
-            "zmedia.com",
-            "conversantmedia.com"
-          ]
-        }
-      },
-      {
         "Convert Insights": {
           "http://www.convert.com/": [
             "convert.com",
@@ -8191,9 +8484,30 @@
         }
       },
       {
+        "DistilNetworks": {
+          "https://www.distilnetworks.com/": [
+            "distiltag.com"
+          ]
+        }
+      },
+      {
+        "DoubleVerify": {
+          "http://www.doubleverify.com/": [
+            "doubleverify.com"
+          ]
+        }
+      },
+      {
         "dwstat.com": {
           "http://www.dwstat.cn/": [
             "dwstat.cn"
+          ]
+        }
+      },
+      {
+        "ECSAnalytics": {
+          "https://www.theecsinc.com/": [
+            "ecsanalytics.com"
           ]
         }
       },
@@ -8203,21 +8517,6 @@
             "trackersimulator.org",
             "eviltracker.net",
             "do-not-tracker.org"
-          ]
-        }
-      },
-      {
-        "Eloqua": {
-          "http://www.eloqua.com/": [
-            "eloqua.com"
-          ]
-        }
-      },
-      {
-        "Encore": {
-          "http://www.encoremetrics.com/": [
-            "encoremetrics.com",
-            "sitecompass.com"
           ]
         }
       },
@@ -8265,6 +8564,14 @@
         "Feedjit": {
           "http://feedjit.com/": [
             "feedjit.com"
+          ]
+        }
+      },
+      {
+        "Flashtalking": {
+          "http://www.flashtalking.com/": [
+            "encoremetrics.com",
+            "sitecompass.com"
           ]
         }
       },
@@ -8339,6 +8646,13 @@
         "GoStats": {
           "http://gostats.com/": [
             "gostats.com"
+          ]
+        }
+      },
+      {
+        "GrapheneMedia": {
+          "http://graphenemedia.in/": [
+            "graphenedigitalanalytics.in"
           ]
         }
       },
@@ -8464,6 +8778,13 @@
         }
       },
       {
+        "IslayTech": {
+          "http://islay.tech": [
+            "islay.tech"
+          ]
+        }
+      },
+      {
         "ItIsATracker": {
           "https://itisatracker.com/": [
             "itisatracker.com"
@@ -8571,9 +8892,10 @@
         }
       },
       {
-        "Maxymiser": {
-          "http://www.maxymiser.com/": [
-            "maxymiser.com"
+        "MaxMind": {
+          "https://www.maxmind.com/en/home": [
+            "maxmind.com",
+            "mmapiws.com"
           ]
         }
       },
@@ -8586,19 +8908,10 @@
         }
       },
       {
-        "Meetrics": {
-          "http://www.meetrics.de/": [
-            "meetrics.de",
-            "meetrics.net",
-            "research.de.com"
-          ]
-        }
-      },
-      {
-        "Merkle RKG": {
+        "Merkle": {
           "https://www.merkleinc.com/": [
-            "rkdms.com",
-            "merkleinc.com"
+            "merkleinc.com",
+            "rkdms.com"
           ]
         }
       },
@@ -8647,6 +8960,14 @@
         }
       },
       {
+        "Mystighty": {
+          "http://mystighty.info/": [
+            "mystighty.info",
+            "sweeterge.info"
+          ]
+        }
+      },
+      {
         "Narrative": {
           "http://narrative.io/2/": [
             "narrative.io"
@@ -8688,6 +9009,13 @@
           "http://www.nielsen.com/": [
             "glanceguide.com",
             "nielsen.com"
+          ]
+        }
+      },
+      {
+        "NuDataSecurity": {
+          "https://nudatasecurity.com/": [
+            "nudatasecurity.com"
           ]
         }
       },
@@ -8738,6 +9066,21 @@
         }
       },
       {
+        "Opolen": {
+          "https://opolen.com.br": [
+            "opolen.com.br"
+          ]
+        }
+      },
+      {
+        "Oracle": {
+          "http://www.oracle.com/": [
+            "eloqua.com",
+            "maxymiser.com"
+          ]
+        }
+      },
+      {
         "ÖWA": {
           "http://www.oewa.at/": [
             "oewa.at",
@@ -8774,18 +9117,24 @@
         }
       },
       {
-        "Pronunciator": {
-          "http://www.pronunciator.com/": [
-            "pronunciator.com",
-            "visitorville.com"
+        "PixAnalytics": {
+          "https://pixanalytics.com/": [
+            "pixanalytics.com"
           ]
         }
       },
       {
-        "Protected Media": {
-          "http://www.protected.media/": [
-            "protected.media",
-            "ad-score.com"
+        "Poool": {
+          "http://poool.fr/": [
+            "poool.fr"
+          ]
+        }
+      },
+      {
+        "Pronunciator": {
+          "http://www.pronunciator.com/": [
+            "pronunciator.com",
+            "visitorville.com"
           ]
         }
       },
@@ -8848,6 +9197,13 @@
         }
       },
       {
+        "Rollick": {
+          "https://gorollick.com": [
+            "rollick.io"
+          ]
+        }
+      },
+      {
         "Roxr": {
           "http://roxr.net/": [
             "getclicky.com",
@@ -8875,6 +9231,13 @@
         }
       },
       {
+        "Salesintelligence": {
+          "https://salesintelligence.pl/": [
+            "plugin.management"
+          ]
+        }
+      },
+      {
         "SeeVolution": {
           "https://www.seevolution.com/": [
             "seevolution.com",
@@ -8886,6 +9249,13 @@
         "Segment.io": {
           "https://segment.io/": [
             "segment.io"
+          ]
+        }
+      },
+      {
+        "SendPulse": {
+          "https://sendpulse.com/": [
+            "sendpulse.com"
           ]
         }
       },
@@ -8902,14 +9272,6 @@
           "http://www.shinystat.com/": [
             "shinystat.com"
           ]
-        }
-      },
-      {
-        "Shortest": {
-          "http://shorte.st/": [
-            "shorte.st"
-          ],
-          "fingerprinting": "true"
         }
       },
       {
@@ -8931,6 +9293,20 @@
         "Soasta": {
           "https://www.soasta.com": [
             "go-mpulse.net"
+          ]
+        }
+      },
+      {
+        "Sputnik.ru": {
+          "http://sputnik.ru": [
+            "sputnik.ru"
+          ]
+        }
+      },
+      {
+        "StackTrack": {
+          "http://stat-track.com": [
+            "stat-track.com"
           ]
         }
       },
@@ -8963,9 +9339,23 @@
         }
       },
       {
+        "Storeland": {
+          "https://storeland.ru/": [
+            "storeland.ru"
+          ]
+        }
+      },
+      {
         "Stratigent": {
           "http://www.stratigent.com/": [
             "stratigent.com"
+          ]
+        }
+      },
+      {
+        "TechSolutions": {
+          "https://www.techsolutions.com.tw/": [
+            "techsolutions.com.tw"
           ]
         }
       },
@@ -8985,6 +9375,13 @@
         }
       },
       {
+        "TinyCloud": {
+          "https://www.tiny.cloud/": [
+            "tinymce.com"
+          ]
+        }
+      },
+      {
         "TNS": {
           "http://www.tnsglobal.com/": [
             "sesamestats.com",
@@ -9000,6 +9397,13 @@
           "http://trackingsoft.com/": [
             "roia.biz",
             "trackingsoft.com"
+          ]
+        }
+      },
+      {
+        "TrafficScore": {
+          "https://trafficscore.com/": [
+            "trafficscore.com"
           ]
         }
       },
@@ -9165,6 +9569,795 @@
             "yellowtracker.com"
           ]
         }
+      },
+      {
+        "YSance": {
+          "https://www.ysance.com/data-services/fr/home/": [
+            "y-track.com"
+          ]
+        }
+      }
+    ],
+    "Fingerprinting": [
+      {
+        "Adabra": {
+          "https://www.adabra.com/": [
+            "adabra.com"
+          ]
+        }
+      },
+      {
+        "Adbot": {
+          "https://adbot.tw/": [
+            "adbot.tw"
+          ]
+        }
+      },
+      {
+        "AdGainerSolutions": {
+          "http://adgainersolutions.com/adgainer/": [
+            "adgainersolutions.com"
+          ]
+        }
+      },
+      {
+        "AdMaven": {
+          "https://ad-maven.com/": [
+            "rensovetors.info",
+            "boudja.com",
+            "ad-maven.com",
+            "agreensdistra.info",
+            "wrethicap.info"
+          ]
+        }
+      },
+      {
+        "Admicro": {
+          "http://www.admicro.vn/": [
+            "admicro.vn",
+            "vcmedia.vn"
+          ]
+        }
+      },
+      {
+        "Adnium": {
+          "https://adnium.com": [
+            "adnium.com",
+            "montwam.top"
+          ]
+        }
+      },
+      {
+        "AdScore": {
+          "http://www.adscoremarketing.com/": [
+            "adsco.re"
+          ]
+        }
+      },
+      {
+        "AdYouLike": {
+          "https://www.adyoulike.com/": [
+            "pulpix.com"
+          ]
+        }
+      },
+      {
+        "AivaLabs": {
+          "https://aivalabs.com": [
+            "aivalabs.com"
+          ]
+        }
+      },
+      {
+        "Albacross": {
+          "https://albacross.com": [
+            "albacross.com"
+          ]
+        }
+      },
+      {
+        "AppCast": {
+          "https://appcast.io/": [
+            "appcast.io"
+          ]
+        }
+      },
+      {
+        "AuditedMedia": {
+          "https://auditedmedia.com/": [
+            "aamsitecertifier.com",
+            "aamapi.com",
+            "auditedmedia.com"
+          ]
+        }
+      },
+      {
+        "Augur": {
+          "http://www.augur.io/": [
+            "augur.io"
+          ]
+        }
+      },
+      {
+        "AvantLink": {
+          "http://www.avantlink.com/": [
+            "avmws.com"
+          ]
+        }
+      },
+      {
+        "Azet": {
+          "http://mediaimpact.sk/": [
+            "rsz.sk",
+            "azetklik.sk"
+          ]
+        }
+      },
+      {
+        "BetssonPalantir": {
+          "https://betssonpalantir.com/": [
+            "betssonpalantir.com"
+          ]
+        }
+      },
+      {
+        "BigClick": {
+          "http://bigclick.me/": [
+            "bgclck.me",
+            "xcvgdf.party"
+          ]
+        }
+      },
+      {
+        "BitMedia": {
+          "https://bitmedia.io/": [
+            "bitmedia.io"
+          ]
+        }
+      },
+      {
+        "BlueCava": {
+          "http://www.bluecava.com/": [
+            "bluecava.com"
+          ]
+        }
+      },
+      {
+        "BoostBox": {
+          "https://www.boostbox.com.br/": [
+            "boostbox.com.br"
+          ]
+        }
+      },
+      {
+        "Brandcrumb": {
+          "http://www.brandcrumb.com": [
+            "brandcrumb.com"
+          ]
+        }
+      },
+      {
+        "BreakTime": {
+          "https://www.breaktime.com.tw/": [
+            "breaktime.com.tw"
+          ]
+        }
+      },
+      {
+        "BrightEdge": {
+          "http://www.brightedge.com/": [
+            "b0e8.com"
+          ]
+        }
+      },
+      {
+        "C3 Metrics": {
+          "http://c3metrics.com/": [
+            "attributionmodel.com",
+            "c3metrics.com",
+            "c3tag.com"
+          ]
+        }
+      },
+      {
+        "CallSource": {
+          "https://www.callsource.com/": [
+            "leadtrackingdata.com"
+          ]
+        }
+      },
+      {
+        "CartsGuru": {
+          "https://carts.guru/": [
+            "carts.guru"
+          ]
+        }
+      },
+      {
+        "Cbox": {
+          "http://www.cbox.ws/": [
+            "cbox.ws"
+          ]
+        }
+      },
+      {
+        "ClearLink": {
+          "https://www.clearlink.com/": [
+            "clearlink.com"
+          ]
+        }
+      },
+      {
+        "Clickayab": {
+          "http://www.clickyab.com": [
+            "clickyab.com"
+          ]
+        }
+      },
+      {
+        "ClickFrog": {
+          "https://clickfrog.ru/": [
+            "quitzon.net",
+            "bashirian.biz",
+            "franecki.net",
+            "buckridge.link",
+            "wisokykulas.bid",
+            "reichelcormier.bid"
+          ]
+        }
+      },
+      {
+        "ClickGuard": {
+          "https://www.clickguard.com/": [
+            "clickguard.com"
+          ]
+        }
+      },
+      {
+        "Clixtell": {
+          "https://www.clixtell.com/": [
+            "clixtell.com"
+          ]
+        }
+      },
+      {
+        "Consumable": {
+          "http://consumable.com/": [
+            "consumable.com"
+          ]
+        }
+      },
+      {
+        "dmpxs": {
+          "http://bob.dmpxs.com": [
+            "dmpxs.com"
+          ]
+        }
+      },
+      {
+        "DoubleVerify": {
+          "http://www.doubleverify.com/": [
+            "doubleverify.com"
+          ]
+        }
+      },
+      {
+        "ECSAnalytics": {
+          "https://www.theecsinc.com/": [
+            "ecsanalytics.com"
+          ]
+        }
+      },
+      {
+        "EroAdvertising": {
+          "http://www.ero-advertising.com/": [
+            "ero-advertising.com"
+          ]
+        }
+      },
+      {
+        "EyeNewton": {
+          "http://eyenewton.ru/": [
+            "eyenewton.ru"
+          ]
+        }
+      },
+      {
+        "eyeReturn Marketing": {
+          "http://www.eyereturnmarketing.com/": [
+            "eyereturn.com",
+            "eyereturnmarketing.com"
+          ]
+        }
+      },
+      {
+        "Fanplayr": {
+          "https://fanplayr.com/": [
+            "fanplayr.com"
+          ]
+        }
+      },
+      {
+        "Foresee": {
+          "https://www.foresee.com": [
+            "answerscloud.com",
+            "foresee.com"
+          ]
+        }
+      },
+      {
+        "Friends2Follow": {
+          "https://friends2follow.com/": [
+            "friends2follow.com"
+          ]
+        }
+      },
+      {
+        "FuelX": {
+          "https://fuelx.com/": [
+            "fuelx.com",
+            "fuel451.com"
+          ]
+        }
+      },
+      {
+        "Gleam": {
+          "https://gleam.io/": [
+            "gleam.io"
+          ]
+        }
+      },
+      {
+        "GrapheneMedia": {
+          "http://graphenemedia.in/": [
+            "graphenedigitalanalytics.in"
+          ]
+        }
+      },
+      {
+        "Gruner + Jahr": {
+          "http://www.guj.de/": [
+            "ligatus.com"
+          ]
+        }
+      },
+      {
+        "HilltopAds": {
+          "https://hilltopads.com/": [
+            "hilltopads.net",
+            "shoporielder.pro"
+          ]
+        }
+      },
+      {
+        "HotelChamp": {
+          "https://www.hotelchamp.com": [
+            "hotelchamp.com"
+          ]
+        }
+      },
+      {
+        "HotMart": {
+          "https://www.hotmart.com/en/": [
+            "hotmart.com"
+          ]
+        }
+      },
+      {
+        "iMedia": {
+          "http://www.imedia.cz": [
+            "imedia.cz"
+          ]
+        }
+      },
+      {
+        "IslayTech": {
+          "http://islay.tech": [
+            "islay.tech"
+          ]
+        }
+      },
+      {
+        "ismatlab.com": {
+          "http://ismatlab.com": [
+            "ismatlab.com"
+          ]
+        }
+      },
+      {
+        "Itch": {
+          "https://itch.io/": [
+            "itch.io"
+          ]
+        }
+      },
+      {
+        "justuno": {
+          "https://www.justuno.com/": [
+            "justuno.com"
+          ]
+        }
+      },
+      {
+        "Konduto": {
+          "http://konduto.com": [
+            "k-analytix.com",
+            "konduto.com"
+          ]
+        }
+      },
+      {
+        "LeadsHub": {
+          "https://ztsrv.com/": [
+            "ztsrv.com"
+          ]
+        }
+      },
+      {
+        "lptracker": {
+          "https://lptracker.io/": [
+            "lptracker.io"
+          ]
+        }
+      },
+      {
+        "MaxMind": {
+          "https://www.maxmind.com/en/home": [
+            "maxmind.com",
+            "mmapiws.com"
+          ]
+        }
+      },
+      {
+        "MediaMath": {
+          "http://www.mediamath.com/": [
+            "mathtag.com",
+            "mediamath.com"
+          ]
+        }
+      },
+      {
+        "Mercadopago": {
+          "https://www.mercadopago.com/": [
+            "mercadopago.com"
+          ]
+        }
+      },
+      {
+        "Mobials": {
+          "http://mobials.com": [
+            "mobials.com"
+          ]
+        }
+      },
+      {
+        "Mystighty": {
+          "http://mystighty.info/": [
+            "mystighty.info",
+            "sweeterge.info"
+          ]
+        }
+      },
+      {
+        "Negishim": {
+          "http://www.negishim.org": [
+            "negishim.org"
+          ]
+        }
+      },
+      {
+        "NuDataSecurity": {
+          "https://nudatasecurity.com/": [
+            "nudatasecurity.com"
+          ]
+        }
+      },
+      {
+        "OneAd": {
+          "https://www.onead.com.tw/": [
+            "onevision.com.tw",
+            "guoshipartners.com"
+          ]
+        }
+      },
+      {
+        "OnlineMetrix": {
+          "http://h.online-metrix.net": [
+            "online-metrix.net"
+          ]
+        }
+      },
+      {
+        "OpenX": {
+          "http://openx.com/": [
+            "openx.net"
+          ]
+        }
+      },
+      {
+        "Opolen": {
+          "https://opolen.com.br": [
+            "opolen.com.br"
+          ]
+        }
+      },
+      {
+        "PaymentsMB": {
+          "https://paymentsmb.com": [
+            "paymentsmb.com"
+          ]
+        }
+      },
+      {
+        "Paypal": {
+          "https://www.paypal.com": [
+            "simility.com"
+          ]
+        }
+      },
+      {
+        "PerimeterX": {
+          "https://www.perimeterx.com": [
+            "perimeterx.net"
+          ]
+        }
+      },
+      {
+        "PinPoll": {
+          "https://pinpoll.com/": [
+            "pinpoll.com"
+          ]
+        }
+      },
+      {
+        "PixAnalytics": {
+          "https://pixanalytics.com/": [
+            "pixanalytics.com"
+          ]
+        }
+      },
+      {
+        "Pixlee": {
+          "https://www.pixlee.com/": [
+            "pixlee.com"
+          ]
+        }
+      },
+      {
+        "Poool": {
+          "http://poool.fr/": [
+            "poool.fr"
+          ]
+        }
+      },
+      {
+        "PPCProtect": {
+          "https://ppcprotect.com": [
+            "ppcprotect.com"
+          ]
+        }
+      },
+      {
+        "PrismApp": {
+          "https://www.prismapp.io/": [
+            "prismapp.io"
+          ]
+        }
+      },
+      {
+        "PrometheusIntelligenceTechnology": {
+          "https://prometheusintelligencetechnology.com/": [
+            "prometheusintelligencetechnology.com"
+          ]
+        }
+      },
+      {
+        "Provers": {
+          "http://provers.pro": [
+            "provers.pro"
+          ]
+        }
+      },
+      {
+        "Psonstrentie": {
+          "http://psonstrentie.info": [
+            "psonstrentie.info"
+          ]
+        }
+      },
+      {
+        "Rollick": {
+          "https://gorollick.com": [
+            "rollick.io"
+          ]
+        }
+      },
+      {
+        "SAP": {
+          "https://www.sap.com": [
+            "seewhy.com"
+          ]
+        }
+      },
+      {
+        "Selectable Media": {
+          "http://selectablemedia.com/": [
+            "nabbr.com",
+            "selectablemedia.com"
+          ]
+        }
+      },
+      {
+        "Semantiqo": {
+          "http://semantiqo.com/": [
+            "semantiqo.com"
+          ]
+        }
+      },
+      {
+        "SendPulse": {
+          "https://sendpulse.com/": [
+            "sendpulse.com"
+          ]
+        }
+      },
+      {
+        "ShaftTraffic": {
+          "https://shafttraffic.com": [
+            "libertystmedia.com"
+          ]
+        }
+      },
+      {
+        "Shortest": {
+          "http://shorte.st/": [
+            "shorte.st"
+          ]
+        }
+      },
+      {
+        "SiftScience": {
+          "https://sift.com/": [
+            "siftscience.com"
+          ]
+        }
+      },
+      {
+        "Signifyd": {
+          "https://www.signifyd.com/": [
+            "signifyd.com"
+          ]
+        }
+      },
+      {
+        "Smi": {
+          "http://24smi.net": [
+            "24smi.net"
+          ]
+        }
+      },
+      {
+        "Socital": {
+          "https://www.socital.com": [
+            "socital.com"
+          ]
+        }
+      },
+      {
+        "StackTrack": {
+          "http://stat-track.com": [
+            "stat-track.com"
+          ]
+        }
+      },
+      {
+        "Storeland": {
+          "https://storeland.ru/": [
+            "storeland.ru"
+          ]
+        }
+      },
+      {
+        "Stripe": {
+          "https://stripe.com": [
+            "stripe.network"
+          ]
+        }
+      },
+      {
+        "TechSolutions": {
+          "https://www.techsolutions.com.tw/": [
+            "techsolutions.com.tw"
+          ]
+        }
+      },
+      {
+        "TinyCloud": {
+          "https://www.tiny.cloud/": [
+            "tinymce.com"
+          ]
+        }
+      },
+      {
+        "tongdun.cn": {
+          "https://www.tongdun.cn/?lan=EN": [
+            "tongdun.net",
+            "fraudmetrix.cn"
+          ]
+        }
+      },
+      {
+        "Upland": {
+          "https://uplandsoftware.com/": [
+            "sf14g.com",
+            "leadlander.com"
+          ]
+        }
+      },
+      {
+        "USocial": {
+          "https://usocial.pro": [
+            "usocial.pro"
+          ]
+        }
+      },
+      {
+        "Vendemore": {
+          "https://vendemore.com/": [
+            "vendemore.com"
+          ]
+        }
+      },
+      {
+        "VerticalHealth": {
+          "https://www.verticalhealth.com/": [
+            "verticalhealth.net"
+          ]
+        }
+      },
+      {
+        "ViralLoops": {
+          "https://viral-loops.com": [
+            "viral-loops.com"
+          ]
+        }
+      },
+      {
+        "Webmecanik": {
+          "https://www.webmecanik.com/": [
+            "webmecanik.com"
+          ]
+        }
+      },
+      {
+        "WideOrbit": {
+          "https://www.wideorbit.com/": [
+            "dep-x.com"
+          ]
+        }
+      },
+      {
+        "YSance": {
+          "https://www.ysance.com/data-services/fr/home/": [
+            "y-track.com"
+          ]
+        }
+      },
+      {
+        "ZafulAffiliate": {
+          "https://affiliate.zaful.com/": [
+            "zaful.com",
+            "gw-ec.com",
+            "affasi.com"
+          ]
+        }
+      },
+      {
+        "Zefir": {
+          "https://ze-fir.com/": [
+            "ze-fir.com"
+          ]
+        }
       }
     ],
     "Social": [
@@ -9206,7 +10399,6 @@
       {
         "Lockerz": {
           "http://lockerz.com/": [
-            "addtoany.com",
             "lockerz.com"
           ]
         }
@@ -9265,6 +10457,13 @@
         }
       },
       {
+        "USocial": {
+          "https://usocial.pro": [
+            "usocial.pro"
+          ]
+        }
+      },
+      {
         "VKontakte": {
           "http://vk.com/": [
             "userapi.com",
@@ -9292,6 +10491,197 @@
             "pulse.yahoo.com",
             "webmessenger.yahoo.com",
             "ymail.com"
+          ]
+        }
+      }
+    ],
+    "Cryptomining": [
+      {
+        "a.js": {
+          "http://zymerget.bid": [
+            "zymerget.bid",
+            "zymerget.faith",
+            "anybest.site",
+            "alflying.win",
+            "flightsy.bid",
+            "flightsy.win",
+            "alflying.date",
+            "flightzy.date",
+            "flightzy.win",
+            "flightzy.bid"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "CashBeet": {
+          "http://cashbeet.com": [
+            "cashbeet.com",
+            "serv1swork.com"
+          ]
+        }
+      },
+      {
+        "CoinHive": {
+          "https://coinhive.com": [
+            "coinhive.com",
+            "coin-hive.com",
+            "cnhv.co",
+            "authedmine.com",
+            "wsservices.org",
+            "bmst.pw",
+            "ad-miner.com"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "CoinPot": {
+          "http://coinpot.co": [
+            "coinpot.co"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "CryptoLoot": {
+          "https://crypto-loot.com": [
+            "crypto-loot.com",
+            "cryptaloot.pro",
+            "webmine.pro",
+            "gitgrub.pro",
+            "statdynamic.com",
+            "cryptolootminer.com",
+            "flashx.pw",
+            "reauthenticator.com"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "CryptoWebMiner": {
+          "https://www.crypto-webminer.com": [
+            "crypto-webminer.com",
+            "ethtrader.de",
+            "bitcoin-pay.eu",
+            "ethpocket.de"
+          ]
+        }
+      },
+      {
+        "Gridcash": {
+          "https://www.gridcash.net/": [
+            "adless.io",
+            "gridcash.net"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "JSE": {
+          "http://jsecoin.com": [
+            "jsecoin.com",
+            "hostingcloud.racing",
+            "freecontent.stream",
+            "hostingcloud.science",
+            "hashing.win",
+            "freecontent.bid",
+            "freecontent.date"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "MinerAlt": {
+          "http://mineralt.io": [
+            "gramombird.com",
+            "mepirtedic.com",
+            "besstahete.info",
+            "feesocrald.com",
+            "analytics.blue",
+            "pampopholf.com",
+            "tulip18.com",
+            "mineralt.io",
+            "dinorslick.icu",
+            "istlandoll.com",
+            "vidzi.tv",
+            "1q2w3.website",
+            "yololike.space",
+            "tercabilis.info",
+            "aster18cdn.nl",
+            "belicimo.pw"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "Minescripts": {
+          "http://minescripts.info": [
+            "minescripts.info",
+            "sslverify.info"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "MineXMR": {
+          "http://minexmr.stream": [
+            "minexmr.stream"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "NeroHut": {
+          "https://nerohut.com": [
+            "nerohut.com",
+            "nhsrv.cf"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "Service4refresh": {
+          "https://service4refresh.info": [
+            "service4refresh.info"
+          ]
+        }
+      },
+      {
+        "SpareChange": {
+          "http://sparechange.io": [
+            "sparechange.io"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "SwiftMining": {
+          "https://swiftmining.win/": [
+            "swiftmining.win"
+          ]
+        }
+      },
+      {
+        "Webmine": {
+          "https://webmine.cz/": [
+            "webmine.cz",
+            "authedwebmine.cz"
+          ]
+        }
+      },
+      {
+        "WebminePool": {
+          "http://webminepool.com": [
+            "webminepool.com"
+          ],
+          "performance": "true"
+        }
+      },
+      {
+        "Webmining": {
+          "https://webmining.co/": [
+            "webmining.co"
           ]
         }
       }
@@ -9341,42 +10731,14 @@
             "teracent.net",
             "ytsa.net",
             "googletagmanager.com",
-            "adservice.google.com"
-          ]
-        }
-      },
-      {
-        "Cnet": {
-          "https://www.cnet.com/": [
-            "2mdn.net"
-          ]
-        }
-      },
-      {
-        "Alexa": {
-          "http://www.alexa.com/": [
-            "pcache.alexa.com"
-          ]
-        }
-      },
-      {
-        "Saturn": {
-          "https://www.saturn.at/": [
-            "google-analytics.com"
-          ]
-        }
-      },
-      {
-        "Mediamarkt": {
-          "https://www.mediamarkt.at/": [
-            "google-analytics.com"
+            "adservice.google.com",
+            "adservice.google.ca"
           ]
         }
       },
       {
         "Twitter": {
           "https://twitter.com/": [
-            "backtype.com",
             "crashlytics.com",
             "tweetdeck.com",
             "twimg.com",


### PR DESCRIPTION
This fixes #31 and brings in the new fingerprinting and cryptoming categories.

With this new list in place, my [comprehensive test page](https://fmarier.github.io/brave-testing/tracking-protection.html) is almost all green.

I also created test pages for [`tinymce.com`](https://fmarier.github.io/brave-testing/tinymce.html) and [`stripe.network`](https://fmarier.github.io/brave-testing/stripe.html) and tested them in Beta after replacing `TrackingProtection.dat` with the new one manually.

While `tinymce.com` is completely broken, stripe worked just fine without `stripe.network`. I was also able to complete a purchase on https://humblebundle.com and so I don't think we need to worry about that one.

I have raised the `tinymce.com` breakage [upstream](https://bugzilla.mozilla.org/show_bug.cgi?id=1544159) but we can probably live with it in the meantime, especially given that it's [not a false positive](https://github.com/disconnectme/disconnect-tracking-protection/blob/master/descriptions.md#TinyCloud).