### PR TITLE
Remove Disconnect customizations and sync with latest Mozilla upstream.

### DIFF
--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -10747,34 +10747,6 @@
             "ads-twitter.com"
           ]
         }
-      },
-      {
-        "Cnet": {
-          "https://www.cnet.com/": [
-            "2mdn.net"
-          ]
-        }
-      },
-      {
-        "Alexa": {
-          "http://www.alexa.com/": [
-            "pcache.alexa.com"
-          ]
-        }
-      },
-      {
-        "Saturn": {
-          "https://www.saturn.at/": [
-            "google-analytics.com"
-          ]
-        }
-      },
-      {
-        "Mediamarkt": {
-          "https://www.mediamarkt.at/": [
-            "google-analytics.com"
-          ]
-        }
       }
     ]
   }

--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -1378,6 +1378,13 @@
         }
       },
       {
+        "Automattic": {
+          "http://automattic.com/": [
+            "pubmine.com"
+          ]
+        }
+      },
+      {
         "Avalanchers": {
           "http://www.avalanchers.com/": [
             "avalanchers.com"
@@ -1505,7 +1512,8 @@
       {
         "BidSwitch": {
           "https://www.bidswitch.com/": [
-            "bidswitch.net"
+            "bidswitch.net",
+            "mfadsrvr.com"
           ]
         }
       },
@@ -2597,6 +2605,13 @@
         "Emego": {
           "http://www.usemax.de/": [
             "usemax.de"
+          ]
+        }
+      },
+      {
+        "Emerse": {
+          "https://www.emerse.com": [
+            "emerse.com"
           ]
         }
       },
@@ -8760,13 +8775,6 @@
           "http://www.intelligencefocus.com/": [
             "domodomain.com",
             "intelligencefocus.com"
-          ]
-        }
-      },
-      {
-        "Intercom": {
-          "https://www.intercom.io/": [
-            "intercom.io"
           ]
         }
       },


### PR DESCRIPTION
This is the first part of #34.

I prepared a new list by reverting [our customizations](https://github.com/brave/tracking-protection/commit/f1de4fb8ffbdedfdc2602b1e4f857e1547ae169b) and that gave me the following diff:

```
--- TrackingProtection-after.txt	2019-04-09 21:42:14.394777225 -0700
+++ TrackingProtection.txt	2019-04-23 16:46:27.641439201 -0700
@@ -1,4 +1,4 @@
-nb_trackers = 2061
+nb_trackers = 2060
 103092804.com
 1q2w3.website
 1rx.io
@@ -1443,7 +1443,6 @@
 payhit.com
 paymentsmb.com
 paypopup.com
-pcache.alexa.com
 pch.com
 peer39.com
 peer39.net
@@ -2061,7 +2060,7 @@
 zymerget.faith
 zypmedia.com
 
-nb_first_parties = 1122
+nb_first_parties = 1118
 24smi.net: 24smi.net
 2leep.com: 2leep.com
 33across.com: 33across.com
@@ -2225,7 +2224,6 @@
 aivalabs.com: aivalabs.com
 akamai.com: imiclk.com
 albacross.com: albacross.com
-alexa.com: pcache.alexa.com
 allstarmediagroup.com: allstarmediagroup.com
 aloodo.com: aloodo.com
 amadesa.com: amadesa.com
@@ -2372,7 +2370,6 @@
 clixtell.com: clixtell.com
 clovenetwork.com: clovenetwork.com
 clustrmaps.com: clustrmaps.com
-cnet.com: 2mdn.net
 cnzz.com: cnzz.com
 cognitivematch.com: cmads.com.tw,cmadsasia.com,cmadseu.com,cmmeglobal.com,cognitivematch.com
 coinhive.com: ad-miner.com,authedmine.com,bmst.pw,cnhv.co,coin-hive.com,coinhive.com,wsservices.org
@@ -2723,7 +2720,6 @@
 mediaforge.com: mediaforge.com
 mediaimpact.sk: azetklik.sk,rsz.sk
 medialets.com: medialets.com
-mediamarkt.at: google-analytics.com
 mediamath.com: adroitinteractive.com,designbloxlive.com,mathtag.com,mediamath.com
 mediametrie-estat.com: estat.com,mediametrie-estat.com
 mediaocean.com: adbuyer.com,mediaocean.com
@@ -2946,7 +2942,6 @@
 sap.com: seewhy.com
 sapient.com: bridgetrack.com,sapient.com
 sas.com: aimatch.com,sas.com
-saturn.at: google-analytics.com
 scandinavianadnetworks.com: scandinavianadnetworks.com
 scribol.com: scribol.com
 searchforce.com: searchforce.com,searchforce.net
```

I tested saturn.at and mediamarkt.at in Beta, both in Desktop and in responsive iPhone5 mode:

- homepage
- product accordion
- product details page
- zooming into a product photo
- adding a product to the shopping cart
- viewing the shopping cart

Google Analytics was not blocked by Shields, even without our explicit whitelist, but Google Tag Manager was.

I tested `cnet.com` both in Desktop and in responsive iPhone5 mode:

- homepage
- opening an article
- viewing a video

Everything was successful except the videos on mobile. The reason is not `2mdn.net` though, it's because of `pubads.g.doubleclick.net`.