### PR TITLE
Unbreak saturn.at on Android by whitelisting Google Analytics

### DIFF
--- a/data/disconnect.json
+++ b/data/disconnect.json
@@ -10756,6 +10756,15 @@
           ]
         }
       }
+    ],
+    "Brave": [
+      {
+        "Saturn": {
+          "https://www.saturn.at/": [
+            "google-analytics.com"
+          ]
+        }
+      }
     ]
   }
 }


### PR DESCRIPTION
Fixes brave/brave-browser#4248 and reopens #32.

This re-adds the following entry:

    saturn.at: google-analytics.com